### PR TITLE
Fix exercise `query-equivalence/equivalent` call

### DIFF
--- a/app/components/exercise.js
+++ b/app/components/exercise.js
@@ -28,6 +28,9 @@ export default class ExerciseComponent extends Component {
       )}&otherQuery=${encodeURIComponent(query)}`,
       {
         method: 'GET',
+        headers: {
+          Accept: "application/json",
+        },
       }
     );
     const json = await response.json();


### PR DESCRIPTION
Fix  `query-equivalence/equivalent` call in exercise component. 

[Dispatch.ex](https://github.com/redpencilio/app-sparql-interactive-tutorial/blob/master/config/dispatcher/dispatcher.ex#L40) expects json as accept types. 

## Before

Status Code: 431 Request Header Fields Too Large

![image](https://user-images.githubusercontent.com/3050307/229819986-6de0238a-897d-4069-a35c-90fef27a75a6.png)

After: 
![image](https://user-images.githubusercontent.com/3050307/229817522-e8b1add8-02d1-40ea-893d-61b7e058095c.png)

